### PR TITLE
Add nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -305,3 +305,6 @@ rsconnect/
 /*_files/
 
 # End of https://www.toptal.com/developers/gitignore/api/r
+
+# Nix output
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,133 @@
+{
+  "nodes": {
+    "cli11": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672791143,
+        "narHash": "sha256-x3/kBlf5LdzkTO4NYOKanZBfcU4oK+fJw9L7cf88LsY=",
+        "owner": "CLIUtils",
+        "repo": "CLI11",
+        "rev": "291c58789c031208f08f4f261a858b5b7083e8e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "CLIUtils",
+        "ref": "v2.3.2",
+        "repo": "CLI11",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "girgs": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1698061854,
+        "narHash": "sha256-i1TQFrB5Ok7HNMWgMp8DRh4nJWkKepNY/0MB5TweEQc=",
+        "owner": "chistopher",
+        "repo": "girgs",
+        "rev": "d0e74e3f7ad714222a57d8cbea3e0f2fe5ec608b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "chistopher",
+        "ref": "master",
+        "repo": "girgs",
+        "type": "github"
+      }
+    },
+    "googletest": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1656350095,
+        "narHash": "sha256-W+OxRTVtemt2esw4P7IyGWXOonUN5ZuscjvzqkYvZbM=",
+        "owner": "google",
+        "repo": "googletest",
+        "rev": "58d77fa8070e8cec2dc1ed015d66b454c8d78850",
+        "type": "github"
+      },
+      "original": {
+        "owner": "google",
+        "ref": "release-1.12.1",
+        "repo": "googletest",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1739020877,
+        "narHash": "sha256-mIvECo/NNdJJ/bXjNqIh8yeoSjVLAuDuTUzAo7dzs8Y=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a79cfe0ebd24952b580b1cf08cd906354996d547",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pybind11": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1726273558,
+        "narHash": "sha256-SNLdtrOjaC3lGHN9MAqTf51U9EzNKQLyTMNPe0GcdrU=",
+        "owner": "pybind",
+        "repo": "pybind11",
+        "rev": "a2e59f0e7065404b44dfe92a28aca47ba1378dc4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pybind",
+        "ref": "v2.13.6",
+        "repo": "pybind11",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "cli11": "cli11",
+        "flake-utils": "flake-utils",
+        "girgs": "girgs",
+        "googletest": "googletest",
+        "nixpkgs": "nixpkgs",
+        "pybind11": "pybind11"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,182 @@
+{
+  description = "WEmbed - Calculate low dimensional weighted node embeddings";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+
+    # CMake dependencies
+    googletest = {
+      url = "github:google/googletest/release-1.12.1";
+      flake = false;
+    };
+    cli11 = {
+      url = "github:CLIUtils/CLI11/v2.3.2";
+      flake = false;
+    };
+    girgs = {
+      url = "github:chistopher/girgs/master";
+      flake = false;
+    };
+    pybind11 = {
+      url = "github:pybind/pybind11/v2.13.6";
+      flake = false;
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, googletest, cli11, girgs, pybind11 }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        python = pkgs.python3;
+      in
+      {
+        packages.default = pkgs.stdenv.mkDerivation {
+          pname = "wembed";
+          version = "0.0.1";
+
+          src = ./.;
+
+          nativeBuildInputs = with pkgs; [
+            cmake
+            ninja
+            pkg-config
+            python3
+            git
+            python3.pkgs.scikit-build-core
+            python3.pkgs.pybind11
+          ];
+
+          buildInputs = with pkgs; [
+            eigen
+            boost
+            gtest
+            sfml
+          ];
+
+          # Copy the pre-fetched dependencies to their expected locations
+          preConfigure = ''
+            mkdir -p build/_deps
+            cp -r ${googletest} build/_deps/googletest-src
+            cp -r ${cli11} build/_deps/cli11-src
+            cp -r ${girgs} build/_deps/girgs-src
+            cp -r ${pybind11} build/_deps/pybind11-src
+            chmod -R +w build/_deps
+          '';
+
+          cmakeFlags = [
+            "-DCMAKE_BUILD_TYPE=Release"
+            "-DFETCHCONTENT_FULLY_DISCONNECTED=ON"
+            "-DFETCHCONTENT_SOURCE_DIR_GOOGLETEST=${googletest}"
+            "-DFETCHCONTENT_SOURCE_DIR_CLI11=${cli11}"
+            "-DFETCHCONTENT_SOURCE_DIR_GIRGS=${girgs}"
+            "-DFETCHCONTENT_SOURCE_DIR_PYBIND11=${pybind11}"
+          ];
+
+          # Handle Python packaging
+          postInstall = ''
+            # Ensure Python package is installed correctly
+            export PYTHONPATH="$out/${python.sitePackages}:$PYTHONPATH"
+            
+            # Make the CLI executable available
+            mkdir -p $out/bin
+            cp bin/cli_wembed $out/bin/wembed
+            chmod +x $out/bin/wembed
+          '';
+
+          meta = with pkgs.lib; {
+            description = "Calculate low dimensional weighted node embeddings";
+            homepage = "https://github.com/Vraier/wembed";
+            license = {
+              fullName = "MIT License";
+              url = "https://opensource.org/licenses/MIT";
+              spdxId = "MIT";
+              file = ./LICENSE;
+            };
+            platforms = platforms.linux;
+            maintainers = with maintainers; [
+              (maintainers.lib.maintainer {
+                name = "Jean-Pierre von der Heydt";
+                email = "heydt@kit.edu";
+                github = "Vraier";
+              })
+              (maintainers.lib.maintainer {
+                name = "Nikolai Maas";
+                email = "nikolai.maas@kit.edu";
+              })
+              (maintainers.lib.maintainer {
+                name = "Dennis Kobert";
+                email = "dennis@kobert.dev";
+                github = "TrueDoctor";
+              })
+            ];
+          };
+        };
+
+        # Add apps to make the CLIs directly runnable
+        apps.default = flake-utils.lib.mkApp {
+          drv = self.packages.${system}.default;
+          name = "wembed";
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            # Build tools
+            cmake
+            ninja
+            pkg-config
+            git
+            
+            # Core dependencies
+            eigen
+            boost
+            gtest
+            sfml
+            
+            # Python tools and dependencies
+            python3
+            python3.pkgs.scikit-build-core
+            python3.pkgs.pybind11
+            python3.pkgs.pip
+            python3.pkgs.virtualenv
+            
+            # Development tools
+            gdb
+            valgrind
+            ccache
+            clang-tools # For clang-format, clang-tidy
+            pre-commit
+
+            # Additional Python development tools
+            python3.pkgs.pytest
+            python3.pkgs.black
+            python3.pkgs.flake8
+          ];
+
+          shellHook = ''
+            echo "Welcome to WEmbed development environment!"
+            echo "Build tools and dependencies are available."
+            
+            # Setup ccache
+            export CCACHE_DIR=$PWD/.ccache
+            export PATH="${pkgs.ccache}/bin:$PATH"
+            
+            # Make tests verbose by default
+            export CTEST_OUTPUT_ON_FAILURE=1
+
+            # Setup Python environment variables
+            export PYTHONPATH="$PWD:$PYTHONPATH"
+            
+            # Create virtual environment if it doesn't exist
+            if [ ! -d ".venv" ]; then
+              python -m venv .venv
+              source .venv/bin/activate
+              pip install -e .
+            else
+              source .venv/bin/activate
+            fi
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
Nix flakes are used by the nix package manager to declaratively build packages, modeling the build tools as dependencies. When entering the development shell, all dependencies use the same version as was used for development, I'd imagine that to be useful for research code. This pull request adds a `flake.nix` (which describes the package) and a `flake.lock` which pins the dependency versions. 

When using nix, users can either run the example cli using 
```bash
nix run . -- --help
```
Or they can run an interactive development shell with all build tools
```bash
nix develop
```